### PR TITLE
Clear all filters except for cities

### DIFF
--- a/assets/event_sources.json
+++ b/assets/event_sources.json
@@ -1,62 +1,19 @@
 {
     "appConfig": {
-        "tagsHeader": [
-            {"name": "community", "fullName": "🫂 Community", "defaultValue": "true"},
-            {"name": "commercial", "fullName": "🎩 Commercial", "defaultValue": "true"},
-            {"name": "nonprofit", "fullName": "🏛️ Nonprofit", "defaultValue": "true"}
-        ],
+        "tagsHeader": [],
         "tagsHidden": ["hidden", "invisible", "internal"],
         "tagsToShow": [
             [
-                {"name": "activism", "fullName": "Critical Work", "defaultValue": "true"},
-                {"name": "palestine", "fullName": "🇵🇸 Palestine", "defaultValue": "true"},
-                {"name": "socialism", "fullName": "🚩 Socialism", "defaultValue": "true"},
-                {"name": "anarchism", "fullname": "🏴 Anarchism", "defaultValue": "true"},
-                {"name": "ecology", "fullName": "🌿 Ecology", "defaultValue": "true"},
-                {"name": "organizing", "fullName": "🤝 Organizing", "defaultValue": "true"}
-            ],
-            [
-                {"name": "activities", "fullName": "Activities", "defaultValue": "true"},
-                {"name": "soccer", "fullName": "⚽ Soccer", "defaultValue": "true"},
-                {"name": "biking", "fullName": "🚲 Biking", "defaultValue": "true"},
-                {"name": "skating", "fullName": "🛼🛹 Skating", "defaultValue": "true"},
-                {"name": "exercise", "fullName": "💪 Exercise", "defaultValue": "true"},
-                {"name": "yoga", "fullName": "🧘 Yoga", "defaultValue": "true"},
-                {"name": "dance", "fullName": "🪩 Dancing", "defaultValue": "true"},
-                {"name": "karaoke", "fullName": "🎤 Karaoke", "defaultValue": "true"},
-                {"name": "singing", "fullName": "🎵 Singing", "defaultValue": "true"},
-                {"name": "games", "fullName": "🀄🖥️ Games", "defaultValue": "true"}
-            ],
-            [
-                {"name": "performance", "fullName": "Performances", "defaultValue": "true"},
-                {"name": "theater", "fullName": "🎭 Theater", "defaultValue": "true"},
-                {"name": "music", "fullName": "🎸 Music", "defaultValue": "true"},
-                {"name": "drag", "fullName": "👠 Drag", "defaultValue": "true"},
-                {"name": "movies", "fullName": "📽️ Film & Movies", "defaultValue": "true"}
-            ],
-            [
-                {"name": "interests", "fullName": "Interest & Hobbies", "defaultValue": "true"},
-                {"name": "diy", "fullName": "🔧 DIY", "defaultValue": "true"},
-                {"name": "books", "fullName": "📚 Books", "defaultValue": "true"},
-                {"name": "food", "fullName": "🍲 Food", "defaultValue": "true"},
-                {"name": "art", "fullName": "🎨 Art", "defaultValue": "true"},
-                {"name": "discussion", "fullName": "🗨️ Yapping & Talking", "defaultValue": "true"},
-                {"name": "sobriety", "fullName": "🚭 Sobriety", "defaultValue": "true"}
-            ],
-            [
-                {"name": "other", "fullName": "Misc", "defaultValue": "true"},
-                {"name": "free stuff", "fullName": "🈶 Free Stuff", "defaultValue": "true"},
-                {"name": "volunteering", "fullName": "♻️ Volunteering", "defaultValue": "true"},
-                {"name": "market", "fullName": "🛍️ Market", "defaultValue": "true"},
-                {"name": "transgender", "fullName": "🏳️‍⚧️ Transgeder :3", "defaultValue": "true"},
-                {"name": "festival", "fullName": "🎪 Festival", "defaultValue": "true"},
-                {"name": "announcement", "fullName": "🗣️ Announcements!!!!", "defaultValue": "true"},
-                {"name": "unknownType", "fullName": "🤷 idk", "defaultValue": "true"}
+                { "name": "location", "fullName": "📍 Location", "defaultValue": "true" },
+                { "name": "triangle", "fullName": "Triangle", "defaultValue": "true" },
+                { "name": "raleigh", "fullName": "Raleigh", "defaultValue": "true" },
+                { "name": "durham", "fullName": "Durham", "defaultValue": "true" },
+                { "name": "hillsborough", "fullName": "Hillsborough", "defaultValue": "true" }
             ]
         ],
         "eventApiToGrab": [
             "/api/events/googleCalendar"
-          ]
+        ]
     },
     "googleCalendar": [
         {
@@ -64,17 +21,7 @@
             "googleCalendarId": "triangleradicalevents@gmail.com",
             "city": "Triangle, NC",
             "filters": [
-                [["market","commercial"], "Market", ["title","description"]],
-                ["palestine", "🇵🇸", ["title","description"]],
-                ["biking", "🚲", ["title","description"]],
-                ["sobriety", "🚭", "title"],
-                ["free stuff", "Free Food", "title"],
-                ["community","commercial"],
-                ["music", "sundown", "title"],
-                ["music", "Dogwood Dell", "title"],
-                [["ecology","food","free stuff"], "Fonticello FF", "title"],
-                [["art"], "First Fridays", "title"],
-                ["unknownType", "This is a tag inserted for code purposes, this tag represents all tags which won't be categorized", "title"]
+                ["triangle"]
             ]
         },
         {
@@ -82,17 +29,7 @@
             "googleCalendarId": "9e40ef8bf31101230505e352e34bd9078973320b4c00328e1dd6e1a9b65e6870@group.calendar.google.com",
             "city": "Raleigh, NC",
             "filters": [
-                [["market","commercial"], "Market", ["title","description"]],
-                ["palestine", "🇵🇸", ["title","description"]],
-                ["biking", "🚲", ["title","description"]],
-                ["sobriety", "🚭", "title"],
-                ["free stuff", "Free Food", "title"],
-                ["community","commercial"],
-                ["music", "sundown", "title"],
-                ["music", "Dogwood Dell", "title"],
-                [["ecology","food","free stuff"], "Fonticello FF", "title"],
-                [["art"], "First Fridays", "title"],
-                ["unknownType", "This is a tag inserted for code purposes, this tag represents all tags which won't be categorized", "title"]
+                ["raleigh"]
             ]
         },
         {
@@ -100,17 +37,7 @@
             "googleCalendarId": "0820dd07ac269b6604c0deddeabea3568fcf6ebdc18996c9bdbb3e0aa3184cd5@group.calendar.google.com",
             "city": "Durham, NC",
             "filters": [
-                [["market","commercial"], "Market", ["title","description"]],
-                ["palestine", "🇵🇸", ["title","description"]],
-                ["biking", "🚲", ["title","description"]],
-                ["sobriety", "🚭", "title"],
-                ["free stuff", "Free Food", "title"],
-                ["community","commercial"],
-                ["music", "sundown", "title"],
-                ["music", "Dogwood Dell", "title"],
-                [["ecology","food","free stuff"], "Fonticello FF", "title"],
-                [["art"], "First Fridays", "title"],
-                ["unknownType", "This is a tag inserted for code purposes, this tag represents all tags which won't be categorized", "title"]
+                ["durham"]
             ]
         },
         {
@@ -118,17 +45,7 @@
             "googleCalendarId" : "comradesinthecommons@gmail.com",
             "city" : "Durham, NC",
             "filters": [
-                [["market","commercial"], "Market", ["title","description"]],
-                ["palestine", "🇵🇸", ["title","description"]],
-                ["biking", "🚲", ["title","description"]],
-                ["sobriety", "🚭", "title"],
-                ["free stuff", "Free Food", "title"],
-                ["community","commercial"],
-                ["music", "sundown", "title"],
-                ["music", "Dogwood Dell", "title"],
-                [["ecology","food","free stuff"], "Fonticello FF", "title"],
-                [["art"], "First Fridays", "title"],
-                ["unknownType", "This is a tag inserted for code purposes, this tag represents all tags which won't be categorized", "title"]
+                ["durham"]
             ]            
         },
         {
@@ -136,17 +53,7 @@
             "googleCalendarId" : "28970aa42f82774cab9dbf1dc4b1d1ee18ce9c9f22bbf8de1c0b747646b97f7d@group.calendar.google.com",
             "city" : "Hillsborough",
             "filters": [
-                [["market","commercial"], "Market", ["title","description"]],
-                ["palestine", "🇵🇸", ["title","description"]],
-                ["biking", "🚲", ["title","description"]],
-                ["sobriety", "🚭", "title"],
-                ["free stuff", "Free Food", "title"],
-                ["community","commercial"],
-                ["music", "sundown", "title"],
-                ["music", "Dogwood Dell", "title"],
-                [["ecology","food","free stuff"], "Fonticello FF", "title"],
-                [["art"], "First Fridays", "title"],
-                ["unknownType", "This is a tag inserted for code purposes, this tag represents all tags which won't be categorized", "title"]
+                ["hillsborough"]
             ]            
         }
     ],

--- a/components/App.vue
+++ b/components/App.vue
@@ -94,19 +94,21 @@ function disableEventSource(name: string) {
 
 function isDisplayingBasedOnTags(event) {
   let shouldHidefromHidden = false; // Whether the event should be hidden due to it having a tag with isHidden set to true
-  let shouldShowfromHeader = false; // Whether the event contains a tag of a tagHeader whis isVisible, which is a pre-requisite to being visible
+  // let shouldShowfromHeader = false; // Whether the event contains a tag of a tagHeader whis isVisible, which is a pre-requisite to being visible
   let shouldShowfromTags = false; //Whether the event contains atleast one tag which is being searched for rn, has to be true.
   // Iterate over all tags of the event
   event.tags?.forEach(tagEvent => {
     tags.value.forEach(tagFilter => {
       if (tagFilter.isHidden && tagEvent === tagFilter.name) { shouldHidefromHidden = true; } // This tag dictates the event should be hidden
-      if (tagFilter.isHeader && tagEvent === tagFilter.name && tagFilter.isVisible) { shouldShowfromHeader = true; } // This tag is a header and is required to show the event
-      if (tagEvent === tagFilter.name && tagFilter.isVisible && !tagFilter.isHeader) { shouldShowfromTags = true; } // This tag allows the event to be shown
+      // if (tagFilter.isHeader && tagEvent === tagFilter.name && tagFilter.isVisible) { shouldShowfromHeader = true; } // This tag is a header and is required to show the event
+      // if (tagEvent === tagFilter.name && tagFilter.isVisible && !tagFilter.isHeader) { shouldShowfromTags = true; } // This tag allows the event to be shown
+      if (tagEvent === tagFilter.name && tagFilter.isVisible) { shouldShowfromTags = true; } // This tag allows the event to be shown
     });
   });
 
   // Determine the final display status based on the conditions evaluated
-  return ((shouldShowfromHeader && shouldShowfromTags) && !shouldHidefromHidden) ? 'list-item' : 'none';
+  // return ((shouldShowfromHeader && shouldShowfromTags) && !shouldHidefromHidden) ? 'list-item' : 'none';
+  return (shouldShowfromTags && !shouldHidefromHidden) ? 'list-item' : 'none';
 }
 
 const updateDisplayingBasedOnTags = () => { //Function that re-renders the calendar by updating the display value of each event and resetting it altogether
@@ -439,7 +441,7 @@ const transformEventSourcesResponse = (eventSources: Ref<Record<string, any>>) =
     <FullCalendar ref="calendarRef" :options='calendarOptions' />
     <div style="display: flex; align-items: center; flex-direction: row;">
       <div class="desc" style="padding-bottom: 0;">
-<!-- 
+        <!-- 
         <p>rva.rip was built with the personal hope that no person in richmond should be without community. The site will
           always be free, without frills, and remain a public utility. The events here are drawn from various 
           <a href="https://github.com/natviii/rva.rip/blob/main/assets/event_sources.json">organizer listings</a> that

--- a/components/FilterModal.vue
+++ b/components/FilterModal.vue
@@ -41,7 +41,7 @@ const emit = defineEmits<{
 const isDevelopment = process.env.NODE_ENV === 'development';
 
 // Accessing tags from the imported JSON
-const tagsHeader = ref(eventSourcesJSON.appConfig.tagsHeader);
+// const tagsHeader = ref(eventSourcesJSON.appConfig.tagsHeader);
 const tagsHidden = ref(eventSourcesJSON.appConfig.tagsHidden);
 const tagsToShow = ref(eventSourcesJSON.appConfig.tagsToShow);
 
@@ -50,12 +50,12 @@ const tagsAllShown = computed(() => {
   let flattened = [];
   for (let i = 0; i < tagsToShow.value.length; i++) {
     if (tagsToShow.value[i].length === 1) {
-      flattened.push(tagsToShow.value[i][0].map(tag => tag.name));
+      flattened.push(tagsToShow.value[i][0].name);
     } else {
       flattened.push(...tagsToShow.value[i].slice(1).map(tag => tag.name)); // Skip the first element (label) and add rest
     }
   }
-  flattened.push(...tagsHeader.value.map(tag => tag.name)); //Add the tagsHeader values to the array, ensuring that they're not left out from the list of ALL TAGS SHOWN
+  // flattened.push(...tagsHeader.value.map(tag => tag.name)); //Add the tagsHeader values to the array, ensuring that they're not left out from the list of ALL TAGS SHOWN
   flattened.push(...tagsHidden.value); //Add the tagsHidden values to the array, ensuring that they're not left out from the list of ALL TAGS SHOWN
   return flattened;
 });
@@ -86,13 +86,13 @@ function toggleTagVisibility(tagName: string) {
 
 <template>
   <VueFinalModal class="popper-box-wrapper" content-class="popper-box-inner" overlay-transition="vfm-fade" content-transition="vfm-fade">
-    <span class="event-headers">
+    <!-- <span class="event-headers">
       Event Purpose
     </span>
     <div class="county-header">
       <TagFilterItem v-for="tag in tagsHeader" :key="tag.name" class="tag-group" :label="tag.fullName" :modelValue="getTagVisibility(tag.name)" @update:modelValue="updateTagVisibility(tag.name, $event)">
       </TagFilterItem>
-    </div>
+    </div> -->
     <span class="event-headers">
       Event Type
     </span>

--- a/server/tagsListServe.ts
+++ b/server/tagsListServe.ts
@@ -4,7 +4,7 @@ export interface Tag {
   name: string;
   isVisible: boolean;
   isHidden: boolean;
-  isHeader: boolean;
+  // isHeader: boolean;
 }
 
 // Helper function to extract source names from URLs
@@ -47,13 +47,13 @@ export function getAllTags(): Tag[] {
   });
 
   const tagsHidden = new Set(eventSourcesJSON.appConfig.tagsHidden);
-  const tagsHeader = new Set(eventSourcesJSON.appConfig.tagsHeader.map(tag => tag.name));
+  // const tagsHeader = new Set(eventSourcesJSON.appConfig.tagsHeader.map(tag => tag.name));
 
   // Convert the set of tags into an array of Tag objects, setting visibility based on tagsHidden
   return Array.from(tagsSet).map(tag => ({
     name: tag,
     isVisible: !tagsHidden.has(tag),  //Whether a tag is visible, this is meant to be updated on the user side
     isHidden: tagsHidden.has(tag),    //Whether a tag indicates that it ought to be hidden. This is permanent, if a tag has isHidden true then any event with it ought to be hidden forever
-    isHeader: tagsHeader.has(tag)     //Whether a tag is a header tag, this means that it's a pre-requisite that atleast one visible Header tag should be on an event for the event to be visible at all.
+    // isHeader: tagsHeader.has(tag)     //Whether a tag is a header tag, this means that it's a pre-requisite that atleast one visible Header tag should be on an event for the event to be visible at all.
   }));
 }

--- a/utils/util.ts
+++ b/utils/util.ts
@@ -72,11 +72,6 @@ export function applyEventTags(source: any, title: string, description: string):
 			}
 		}
 	});
-	//Also apply name of calendar as a tag
-	//tags.push('🗓️ '+source.name);
-
-	// Adds the default tag `unknownType` if there's less than two tags on an event (each tag is ALWAYS assigned a header tag, so this is an easy way to check if it's been given any non-Header tags)
-	if (tags.length < 2) tags.push('unknownType');
 
 	return tags;
 }


### PR DESCRIPTION
This commit should make location filters work and remove all other filters for now. Below I've written up an overview of how the filters work.

### How filters work:

* Filters that will be listed in the FilterModal are listed in `appConfig`. There are 2 types:
  * `tagsHeader`: originally "community", "commercial", "nonprofit" - it was required that at least one of these was on each event. They filter independently from the regular tags. I've removed them for now, so we only show filters we've got set up.
  * `tagsToShow`: an array of arrays, where the first item in each array is the header of a section, and everything else is a tag that could be listed in `filters` on events (see below). I've removed everything except "location" for now.

* Tags are created based on `eventSource.filters` in `event_sources.json` and `getAllTags` in `tagsListServe.ts`. The way it works is:
  * For each event that comes back from a source (e.g. Google Calendar), we give it an array of tags, based on the filter criteria listed in `source.filters`, which is an array of arrays. For each array in the `filters` array, the first item is either a string or array of tags.
    * if the filter array is only 1 item long, everything in the first item of that array gets added to that event's `tags` list
      * e.g. if the filter was `["music"]`, we'd add `music` to the event's `tags`. If the filter was `[["ecology","food","free stuff"]]`, we'd add each of those 3 tags to the `tags` list.
    * if the filter array is exactly 2 items long,  we add everything in the first item to `tags` unless anything in the second item is already in `tags`
      * e.g. if the filter is `["community","commercial"]`, then we add the tag "community" to `tags` UNLESS "commercial" already exists in `tags`
    * if the filter array is 3 or more items long, the second item is a regex expression and the third item is the field(s) to search for that expression
      * e.g. if the filter array is `[["market","commercial"], "Market", ["title","description"]]`, we would search the event's title and description for "Market", and if it's found, then we add the items "market" and "commercial" to `tags`

* All the tags have the isVisible property initialized (in `getAllTags`), which is then updated based on the user checking/unchecking the item in the FilterModal, and then the item displays or not based on isVisible (setting `display` in `isDisplayingBasedOnTags`)

Tbh I'm not sure this is the best way to structure the filters, but we can go with it for now or update as we see fit.