### PR TITLE
Fixup wp-tribes event configuration

### DIFF
--- a/assets/event_sources.json
+++ b/assets/event_sources.json
@@ -14,7 +14,8 @@
             ]
         ],
         "eventApiToGrab": [
-            "/api/events/googleCalendar"
+            "/api/events/googleCalendar",
+            "/api/events/wordpress-tribe"
         ]
     },
     "googleCalendar": [

--- a/components/EventModal.vue
+++ b/components/EventModal.vue
@@ -23,7 +23,7 @@ const eventURL = props.event.event.url;
 const eventID = props.event.event.id;
 const eventLocation = props.event.event.extendedProps.location;
 const eventDescription = replaceBadgePlaceholders(sanitizeHtml(props.event.event.extendedProps.description));
-const eventImages = props.event.event.extendedProps.images;
+const eventImages = props.event.event.extendedProps.images || [];
 const eventTags = props.event.event.extendedProps.tags;
 
 //For interpreting the location into a google maps recognizable address

--- a/server/api/events/wordpress-tribe.ts
+++ b/server/api/events/wordpress-tribe.ts
@@ -1,5 +1,5 @@
 import eventSourcesJSON from '@/assets/event_sources.json';
-import { logTimeElapsedSince, serverCacheMaxAgeSeconds, serverStaleWhileInvalidateSeconds, serverFetchHeaders } from '~~/utils/util';
+import { logTimeElapsedSince, serverCacheMaxAgeSeconds, serverStaleWhileInvalidateSeconds, serverFetchHeaders, applyEventTags } from '~~/utils/util';
 
 export default defineCachedEventHandler(async (event) => {
 	const startTime = new Date();
@@ -42,18 +42,23 @@ async function fetchWordPressTribeEvents() {
 };
 
 // The following conversion function is basically ripped from anarchism.nyc.
-function convertWordpressTribeEventToFullCalendarEvent(e) {
+// e is the event data
+// source is the event source configuration
+function convertWordpressTribeEventToFullCalendarEvent(e, source) {
 	var geoJSON = (e.venue.geo_lat && e.venue.geo_lng)
 		? {
 			type: "Point",
-			coordinates: [e.venue.geo_lng, e.venue.geo_lat]
+			coordinates: [ e.venue.geo_lng, e.venue.geo_lat ]
 		}
 		: null;
+
+	const tags = applyEventTags(source, e.title, e.description)
 	return {
 		title: e.title,
 		start: new Date(e.utc_start_date + 'Z'),
 		end: new Date(e.utc_end_date + 'Z'),
 		url: e.url,
+		tags,
 		extendedProps: {
 			description: e.description,
 			image: e.image.url,


### PR DESCRIPTION
This PR:
- Adds the wordpress-tribe event-source configuration to the `eventApiToGrab` in order to load the events at the same time as the google calendar events
- Updates the `api/events/wordpress-tribes.ts` code to add tags to the events when mapping them from the wp-tribes format to the App format. Without `tags` events do not display on the calendar by default.

From my local machine:

<img width="949" height="931" alt="Screenshot 2026-02-03 at 12 45 35 AM" src="https://github.com/user-attachments/assets/eeafc275-4c41-43e1-8b34-6906ea7097dd" />
