### PR TITLE
Fix wordpress-tribe event mapping for calendar display

### DIFF
--- a/server/api/events/wordpress-tribe.ts
+++ b/server/api/events/wordpress-tribe.ts
@@ -28,7 +28,7 @@ async function fetchWordPressTribeEvents() {
 				wpEvents = wpEvents.concat(wpJson.events);
 			}
 			return {
-				events: wpEvents.map(convertWordpressTribeEventToFullCalendarEvent),
+				events: wpEvents.map(e => convertWordpressTribeEventToFullCalendarEvent(e, source)),
 				city: source.city,
 				name: source.name,
 			} as EventNormalSource;
@@ -61,7 +61,7 @@ function convertWordpressTribeEventToFullCalendarEvent(e, source) {
 		tags,
 		extendedProps: {
 			description: e.description,
-			image: e.image.url,
+			images: e.image?.url ? [e.image.url] : [],
 			location: {
 				geoJSON: geoJSON,
 				eventVenue: {


### PR DESCRIPTION
- Pass source config to convertWordpressTribeEventToFullCalendarEvent so applyEventTags can access filters and apply city tags correctly
- Change extendedProps.image (string) to extendedProps.images (array) to match EventModal.vue expected format
- Add optional chaining for e.image to handle events without images