### PR TITLE
Event modal fixes

### DIFF
--- a/assets/event_sources.json
+++ b/assets/event_sources.json
@@ -127,6 +127,7 @@
         "name" : "The Burrow",
         "url" : "https://durhamburrow.xyz/wp-json/tribe/events/v1/events?per_page=50&categories=9",
         "city" : "Durham, NC",
+        "defaultLocation": "The Burrow, 207 N. Church St., Durham",
         "filters": [
             { "tags": ["durham"] }
         ]

--- a/components/EventModal.vue
+++ b/components/EventModal.vue
@@ -58,8 +58,8 @@ const getImageClass = (index) => {
     <div class="event-details">
       <span class="event-headers">Event Title:</span> <span v-html="eventTitle"></span><br>
       <span class="event-headers">Event Time:</span> {{ eventTime }}<br>
-      <span class="event-headers">Event Host:</span> {{ eventHost }}<br>
-      <span v-if="isDevelopment"> <span class="event-headers">Event ID: </span> {{ eventID }}<br> </span>
+      <span v-if="eventHost"> <span class="event-headers">Event Host:</span> {{ eventHost }}<br> </span>
+      <span v-if="isDevelopment && eventID"> <span class="event-headers">Event ID: </span> {{ eventID }}<br> </span>
       <span v-if="isDevelopment"> <span class="event-headers">Event Images: </span> {{ eventImages }}<br> </span>
       <span v-if="isDevelopment"> <span class="event-headers">Event Tags: </span> {{ eventTags }}<br> </span>
       <span v-if="isDevelopment"> <span class="event-headers">Event URL:</span> <a :href="eventURL" target="_blank">Here</a><br> </span>

--- a/components/EventModal.vue
+++ b/components/EventModal.vue
@@ -19,6 +19,7 @@ const eventTitle = replaceBadgePlaceholders(rawEventTitle);
 const eventTime = props.event.event.start.toLocaleDateString() + ' @ ' + 
                   props.event.event.start.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
 const eventHost = props.event.event.extendedProps.org;
+const eventOrganizer = props.event.event.extendedProps.organizer;
 const eventURL = props.event.event.url;
 const eventID = props.event.event.id;
 const rawLocation = props.event.event.extendedProps.location;
@@ -34,6 +35,10 @@ function formatLocation(loc) {
 const eventDescription = replaceBadgePlaceholders(sanitizeHtml(props.event.event.extendedProps.description));
 const eventImages = props.event.event.extendedProps.images || [];
 const eventTags = props.event.event.extendedProps.tags;
+const parsedExtendedProps = JSON.stringify(
+  Object.fromEntries(Object.entries(props.event.event.extendedProps).filter(([k]) => k !== 'raw')),
+  null, 2
+);
 
 //For interpreting the location into a google maps recognizable address
 function createGoogleMapsURL(location) {
@@ -63,55 +68,62 @@ const getImageClass = (index) => {
 
 <template>
   <VueFinalModal class="popper-box-wrapper" content-class="popper-box-inner" overlay-transition="vfm-fade" content-transition="vfm-fade">
+    <!-- Event Header -->
+    <div class="event-header">
+      <h1 v-html="eventTitle"></h1>
+      <div class="event-meta">
+        <span>{{ eventTime }}</span>
+        <span v-if="eventLocation"> · <a :href="createGoogleMapsURL(eventLocation)" target="_blank">{{ eventLocation }}</a></span>
+      </div>
+    </div>
+
+    <!-- Display Images -->
+    <div v-if="getImageUrls().length" class="image-container">
+      <div
+        class="image-wrapper"
+        v-for="(url, index) in getImageUrls()"
+        :key="index"
+      >
+        <div v-if="errorMessages[index]">
+          {{ errorMessages[index] }}
+        </div>
+        <img
+          class="event-image"
+          v-else
+          :src="url"
+          :class="getImageClass(index)"
+          @error="handleImageError(index)"
+          alt="Image found within the description of this calendar event"
+        />
+      </div>
+    </div>
+
     <!-- Display Event Details -->
     <div class="event-details">
-      <span class="event-headers">Event Title:</span> <span v-html="eventTitle"></span><br>
-      <span class="event-headers">Event Time:</span> {{ eventTime }}<br>
-      <span v-if="eventHost"> <span class="event-headers">Event Host:</span> {{ eventHost }}<br> </span>
-      <span v-if="eventLocation"> <span class="event-headers">Event Location:</span> <a :href="createGoogleMapsURL(eventLocation)" target="_blank">{{ eventLocation }}</a><br> </span>
-      <!-- Display Images -->
-      <div class="image-container">
-        <div 
-          class="image-wrapper"
-          v-for="(url, index) in getImageUrls()" 
-          :key="index"
-        >
-          <!-- Check if there's an error message for this image, if so, display the message instead of image -->
-          <div v-if="errorMessages[index]">
-            {{ errorMessages[index] }}
-          </div>   
-          <!-- If there's no error message, render the image as usual --> 
-          <img
-            class="event-image"
-            v-else
-            :src="url"
-            :class="getImageClass(index)"
-            @error="handleImageError(index)"
-            alt="Image found within the description of this calendar event"
-          />
-        </div>
+      <div v-if="eventHost" class="event-field">
+        <span class="event-headers">Event Host:</span> {{ eventHost }}
       </div>
-      <span class="event-headers">Event Description:</span> <div v-html="eventDescription"></div><br>
+      <div class="event-field">
+        <span class="event-headers">Description:</span>
+        <div v-if="eventDescription" v-html="eventDescription"></div>
+        <div v-else class="no-description"><em>No description provided</em></div>
+      </div>
+      <div v-if="eventOrganizer" class="event-field">
+        <span class="event-headers">Organizer:</span><br/>
+        <div v-html="eventOrganizer" />
+      </div>
     </div>
 
     <!-- Dev-only debug info -->
     <div v-if="isDevelopment" class="dev-info">
       <span class="dev-label">Dev Only</span>
-      <dl class="dev-fields">
-        <template v-if="eventID">
-          <dt>Event ID</dt>
-          <dd>{{ eventID }}</dd>
-        </template>
-        <dt>Event Images</dt>
-        <dd>{{ eventImages }}</dd>
-        <dt>Tags</dt>
-        <dd>{{ eventTags }}</dd>
-        <dt>Event URL</dt>
-        <dd><a :href="eventURL" target="_blank">{{ eventURL }}</a></dd>
-      </dl>
+      <details class="dev-raw">
+        <summary>Parsed JSON</summary>
+        <pre>{{ parsedExtendedProps }}</pre>
+      </details>
       <details class="dev-raw">
         <summary>Raw Event JSON</summary>
-        <pre>{{ JSON.stringify(props.event.event.extendedProps, null, 2) }}</pre>
+        <pre>{{ props.event.event.extendedProps.raw || JSON.stringify(props.event.event.extendedProps, null, 2) }}</pre>
       </details>
     </div>
 
@@ -125,6 +137,49 @@ const getImageClass = (index) => {
 </template>
 
 <style scoped>
+.event-header {
+  position: sticky;
+  top: -1rem;
+  background: var(--background-alt);
+  padding-top: 1rem;
+  padding-bottom: 8px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid #e0e0e0;
+  z-index: 1;
+}
+
+.event-header h1 {
+  margin: 0 0 4px;
+  font-size: 1.7rem;
+  text-align: center;
+}
+
+.event-meta {
+  color: #666;
+  font-size: 0.9em;
+  text-align: center;
+}
+
+.image-container {
+  margin-bottom: 16px;
+  padding: 8px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background-color: #fafafa;
+}
+
+.event-details {
+  margin-bottom: 8px;
+}
+
+.event-field {
+  margin-bottom: 8px;
+}
+
+.no-description {
+  color: #999;
+}
+
 .dev-info {
   margin-top: 12px;
   padding: 8px;

--- a/components/EventModal.vue
+++ b/components/EventModal.vue
@@ -21,7 +21,16 @@ const eventTime = props.event.event.start.toLocaleDateString() + ' @ ' +
 const eventHost = props.event.event.extendedProps.org;
 const eventURL = props.event.event.url;
 const eventID = props.event.event.id;
-const eventLocation = props.event.event.extendedProps.location;
+const rawLocation = props.event.event.extendedProps.location;
+const eventLocation = formatLocation(rawLocation);
+
+function formatLocation(loc) {
+  if (!loc) return '';
+  if (typeof loc === 'string') return loc;
+  const venue = loc.eventVenue;
+  if (!venue) return '';
+  return [venue.name, venue.address?.streetAddress, venue.address?.addressLocality].filter(Boolean).join(', ');
+}
 const eventDescription = replaceBadgePlaceholders(sanitizeHtml(props.event.event.extendedProps.description));
 const eventImages = props.event.event.extendedProps.images || [];
 const eventTags = props.event.event.extendedProps.tags;
@@ -59,7 +68,7 @@ const getImageClass = (index) => {
       <span class="event-headers">Event Title:</span> <span v-html="eventTitle"></span><br>
       <span class="event-headers">Event Time:</span> {{ eventTime }}<br>
       <span v-if="eventHost"> <span class="event-headers">Event Host:</span> {{ eventHost }}<br> </span>
-      <span class="event-headers">Event Location:</span> <a :href="createGoogleMapsURL(eventLocation)" target="_blank">{{ eventLocation }}</a><br>
+      <span v-if="eventLocation"> <span class="event-headers">Event Location:</span> <a :href="createGoogleMapsURL(eventLocation)" target="_blank">{{ eventLocation }}</a><br> </span>
       <!-- Display Images -->
       <div class="image-container">
         <div 

--- a/components/EventModal.vue
+++ b/components/EventModal.vue
@@ -19,7 +19,6 @@ const eventTitle = replaceBadgePlaceholders(rawEventTitle);
 const eventTime = props.event.event.start.toLocaleDateString() + ' @ ' + 
                   props.event.event.start.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
 const eventHost = props.event.event.extendedProps.org;
-const eventOrganizer = props.event.event.extendedProps.organizer;
 const eventURL = props.event.event.url;
 const eventID = props.event.event.id;
 const rawLocation = props.event.event.extendedProps.location;
@@ -107,10 +106,6 @@ const getImageClass = (index) => {
         <span class="event-headers">Description:</span>
         <div v-if="eventDescription" v-html="eventDescription"></div>
         <div v-else class="no-description"><em>No description provided</em></div>
-      </div>
-      <div v-if="eventOrganizer" class="event-field">
-        <span class="event-headers">Organizer:</span><br/>
-        <div v-html="eventOrganizer" />
       </div>
     </div>
 

--- a/components/EventModal.vue
+++ b/components/EventModal.vue
@@ -61,7 +61,7 @@ const getImageClass = (index) => {
       <span v-if="eventHost"> <span class="event-headers">Event Host:</span> {{ eventHost }}<br> </span>
       <span v-if="isDevelopment && eventID"> <span class="event-headers">Event ID: </span> {{ eventID }}<br> </span>
       <span v-if="isDevelopment"> <span class="event-headers">Event Images: </span> {{ eventImages }}<br> </span>
-      <span v-if="isDevelopment"> <span class="event-headers">Event Tags: </span> {{ eventTags }}<br> </span>
+      <span v-if="isDevelopment && eventTags && eventTags.length"> <span class="event-headers">Tags:</span> <span class="event-tag" v-for="tag in eventTags" :key="tag">{{ tag }}</span><br> </span>
       <span v-if="isDevelopment"> <span class="event-headers">Event URL:</span> <a :href="eventURL" target="_blank">Here</a><br> </span>
       <span class="event-headers">Event Location:</span> <a :href="createGoogleMapsURL(eventLocation)" target="_blank">{{ eventLocation }}</a><br>
       <!-- Display Images -->
@@ -97,3 +97,15 @@ const getImageClass = (index) => {
     </div>
   </VueFinalModal>
 </template>
+
+<style scoped>
+.event-tag {
+  display: inline-block;
+  background-color: #e0e0e0;
+  color: #333;
+  padding: 2px 8px;
+  margin: 2px 4px;
+  border-radius: 12px;
+  font-size: 0.85em;
+}
+</style>

--- a/components/EventModal.vue
+++ b/components/EventModal.vue
@@ -59,10 +59,6 @@ const getImageClass = (index) => {
       <span class="event-headers">Event Title:</span> <span v-html="eventTitle"></span><br>
       <span class="event-headers">Event Time:</span> {{ eventTime }}<br>
       <span v-if="eventHost"> <span class="event-headers">Event Host:</span> {{ eventHost }}<br> </span>
-      <span v-if="isDevelopment && eventID"> <span class="event-headers">Event ID: </span> {{ eventID }}<br> </span>
-      <span v-if="isDevelopment"> <span class="event-headers">Event Images: </span> {{ eventImages }}<br> </span>
-      <span v-if="isDevelopment && eventTags && eventTags.length"> <span class="event-headers">Tags:</span> <span class="event-tag" v-for="tag in eventTags" :key="tag">{{ tag }}</span><br> </span>
-      <span v-if="isDevelopment"> <span class="event-headers">Event URL:</span> <a :href="eventURL" target="_blank">Here</a><br> </span>
       <span class="event-headers">Event Location:</span> <a :href="createGoogleMapsURL(eventLocation)" target="_blank">{{ eventLocation }}</a><br>
       <!-- Display Images -->
       <div class="image-container">
@@ -89,6 +85,27 @@ const getImageClass = (index) => {
       <span class="event-headers">Event Description:</span> <div v-html="eventDescription"></div><br>
     </div>
 
+    <!-- Dev-only debug info -->
+    <div v-if="isDevelopment" class="dev-info">
+      <span class="dev-label">Dev Only</span>
+      <dl class="dev-fields">
+        <template v-if="eventID">
+          <dt>Event ID</dt>
+          <dd>{{ eventID }}</dd>
+        </template>
+        <dt>Event Images</dt>
+        <dd>{{ eventImages }}</dd>
+        <dt>Tags</dt>
+        <dd>{{ eventTags }}</dd>
+        <dt>Event URL</dt>
+        <dd><a :href="eventURL" target="_blank">{{ eventURL }}</a></dd>
+      </dl>
+      <details class="dev-raw">
+        <summary>Raw Event JSON</summary>
+        <pre>{{ JSON.stringify(props.event.event.extendedProps, null, 2) }}</pre>
+      </details>
+    </div>
+
     <!-- Add a "Done" button -->
     <div class="bottom">
       <button @click="emit('confirm')">
@@ -99,13 +116,55 @@ const getImageClass = (index) => {
 </template>
 
 <style scoped>
-.event-tag {
+.dev-info {
+  margin-top: 12px;
+  padding: 8px;
+  border: 1px dashed #999;
+  border-radius: 4px;
+  font-size: 0.9em;
+  opacity: 0.8;
+}
+
+.dev-label {
   display: inline-block;
-  background-color: #e0e0e0;
-  color: #333;
-  padding: 2px 8px;
-  margin: 2px 4px;
-  border-radius: 12px;
+  background-color: #f0ad4e;
+  color: #fff;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.75em;
+  font-weight: bold;
+  margin-bottom: 6px;
+}
+
+.dev-fields {
+  margin: 4px 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 8px;
+}
+
+.dev-fields dt {
+  font-weight: bold;
+}
+
+.dev-fields dd {
+  margin: 0;
+  word-break: break-all;
+}
+
+.dev-raw {
+  margin-top: 8px;
+}
+
+.dev-raw pre {
+  margin: 4px 0 0;
+  padding: 8px;
+  background-color: #f5f5f5;
+  border-radius: 4px;
   font-size: 0.85em;
+  max-height: 300px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
 }
 </style>

--- a/server/api/events/wordpress-tribe.ts
+++ b/server/api/events/wordpress-tribe.ts
@@ -101,7 +101,7 @@ function convertWordpressTribeEventToFullCalendarEvent(e, source) {
 		extendedProps: {
 			raw: JSON.stringify(e, null, 2),
 			description,
-			organizer,
+			org: organizer,
 			images: e.image?.url ? [ e.image.url ] : [],
 			location: venue
 				? {

--- a/server/api/events/wordpress-tribe.ts
+++ b/server/api/events/wordpress-tribe.ts
@@ -19,40 +19,79 @@ async function fetchWordPressTribeEvents() {
 	let wordPressTribeSources = await useStorage().getItem('wordPressTribeSources');
 	try {
 		wordPressTribeSources = await Promise.all(
-		eventSourcesJSON.wordPressTribe.map(async (source) => {
-			let wpJson = await (await fetch(source.url, { headers: serverFetchHeaders })).json();
-			let wpEvents = wpJson.events;
-			while (Object.hasOwn(wpJson, 'next_rest_url')) {
-				let next_page_url = wpJson.next_rest_url;
-				wpJson = await (await fetch(next_page_url, { headers: serverFetchHeaders })).json();
-				wpEvents = wpEvents.concat(wpJson.events);
+			eventSourcesJSON.wordPressTribe.map(async (source) => {
+				let wpJson = await (await fetch(source.url, { headers: serverFetchHeaders })).json();
+				let wpEvents = wpJson.events;
+				while (Object.hasOwn(wpJson, 'next_rest_url')) {
+					let next_page_url = wpJson.next_rest_url;
+					wpJson = await (await fetch(next_page_url, { headers: serverFetchHeaders })).json();
+					wpEvents = wpEvents.concat(wpJson.events);
+				}
+				return {
+					events: wpEvents.map(e => convertWordpressTribeEventToFullCalendarEvent(e, source)),
+					city: source.city,
+					name: source.name,
+				} as EventNormalSource;
 			}
-			return {
-				events: wpEvents.map(e => convertWordpressTribeEventToFullCalendarEvent(e, source)),
-				city: source.city,
-				name: source.name,
-			} as EventNormalSource;
-		}
-		));
+			));
 		await useStorage().setItem('wordPressTribeSources', wordPressTribeSources);
 	} catch (error) {
 		console.error(error);
 	}
+
 	return wordPressTribeSources;
 };
+
+// Strip Tribe Events plugin markup from description HTML.
+// The API response embeds schedule, price, organizer, venue, and "add to calendar"
+// blocks that duplicate data we already extract into structured fields.
+function stripTribeMarkup(html: string): { description: string, organizer: string } {
+	if (!html) return { description: '', organizer: '' };
+	// Extract organizer name before stripping tribe blocks
+	const organizerMatch = html.match(/<div[^>]*tribe-block__organizer__details[^>]*>[\s\S]*?<h3>([\s\S]*?)<\/h3>/i);
+	const organizer = organizerMatch ? organizerMatch[ 1 ].trim() : '';
+	// Remove top-level tribe divs (handles nested divs by counting open/close tags)
+	html = stripTagsByClass(html, 'tribe-');
+	// Remove <figure> blocks (tribe embeds images as figures; we extract images separately)
+	html = html.replace(/<figure[^>]*>[\s\S]*?<\/figure>/gi, '');
+	// Remove empty paragraphs
+	html = html.replace(/<p>\s*<\/p>/gi, '');
+	return { description: html.trim(), organizer };
+}
+
+function stripTagsByClass(html: string, classPrefix: string): string {
+	const pattern = new RegExp(`<div[^>]*class="[^"]*${classPrefix}[^"]*"[^>]*>`, 'gi');
+	let match;
+	while ((match = pattern.exec(html)) !== null) {
+		let depth = 1;
+		let i = match.index + match[ 0 ].length;
+		while (i < html.length && depth > 0) {
+			if (html.slice(i).startsWith('<div')) depth++;
+			if (html.slice(i).startsWith('</div>')) depth--;
+			if (depth > 0) i++;
+			else break;
+		}
+		const end = i + '</div>'.length;
+		html = html.slice(0, match.index) + html.slice(end);
+		pattern.lastIndex = match.index; // reset since we mutated the string
+	}
+	return html;
+}
 
 // The following conversion function is basically ripped from anarchism.nyc.
 // e is the event data
 // source is the event source configuration
 function convertWordpressTribeEventToFullCalendarEvent(e, source) {
-	var geoJSON = (e.venue.geo_lat && e.venue.geo_lng)
+	const venue = (!Array.isArray(e.venue) && e.venue?.venue) ? e.venue : null;
+	var geoJSON = (venue?.geo_lat && venue?.geo_lng)
 		? {
 			type: "Point",
-			coordinates: [ e.venue.geo_lng, e.venue.geo_lat ]
+			coordinates: [ venue.geo_lng, venue.geo_lat ]
 		}
 		: null;
 
 	const tags = applyEventTags(source, e.title, e.description)
+	const { description, organizer } = stripTribeMarkup(e.description);
 	return {
 		title: e.title,
 		start: new Date(e.utc_start_date + 'Z'),
@@ -60,24 +99,28 @@ function convertWordpressTribeEventToFullCalendarEvent(e, source) {
 		url: e.url,
 		tags,
 		extendedProps: {
-			description: e.description,
-			images: e.image?.url ? [e.image.url] : [],
-			location: {
-				geoJSON: geoJSON,
-				eventVenue: {
-					name: e.venue.venue,
-					address: {
-						streetAddress: e.venue.address,
-						addressLocality: e.venue.city,
-						postalCode: e.venue.zip,
-						addressCountry: e.venue.country
-					},
-					geo: {
-						latitude: e.venue.geo_lat,
-						longitude: e.venue.geo_lng
+			raw: JSON.stringify(e, null, 2),
+			description,
+			organizer,
+			images: e.image?.url ? [ e.image.url ] : [],
+			location: venue
+				? {
+					geoJSON: geoJSON,
+					eventVenue: {
+						name: venue.venue,
+						address: {
+							streetAddress: venue.address,
+							addressLocality: venue.city,
+							postalCode: venue.zip,
+							addressCountry: venue.country
+						},
+						geo: {
+							latitude: venue.geo_lat,
+							longitude: venue.geo_lng
+						}
 					}
 				}
-			}
+				: source.defaultLocation || '',
 		}
 	};
 }


### PR DESCRIPTION
## Event Modal Fixes

**WordPress Tribe API cleanup:**
- Strip Tribe Events plugin boilerplate (schedule, price, organizer, venue, "add to calendar" blocks) from description HTML
- Extract organizer name from tribe markup, map to `org` field so it displays as "Event Host" similar to the google calendar events
- Fix un-handled case when `e.venue` is an empty array — safely fallback to `null`
- Added `source.defaultLocation` as "The Burrow, 207 N. Church St., Durham" to the wordpressTribe event-source config. This is now used as a fallback location when no venue information is provided
- Embed raw event JSON in `extendedProps.raw` for debugging

**Event modal redesign:**
- Sticky header with title, time, and location as centered text above image
- Location formatted as a readable string linked to Google Maps; hidden when absent
- Event Host now shows the "organizer" data from the wordpress-tribe event detail
- Images moved below header and above description
- Dev-only fields (raw JSON, parsed props) are now shown collapsed into `<details>` dropdowns at the bottom

---
BEFORE CHANGES:
<img width="1030" height="996" alt="Screenshot 2026-02-27 at 3 28 55 PM" src="https://github.com/user-attachments/assets/367e2644-e7db-4249-9d1a-a7d18049e319" />
---
AFTER CHANGES:
<img width="1050" height="982" alt="Screenshot 2026-02-27 at 3 29 09 PM" src="https://github.com/user-attachments/assets/5aaa5f42-2966-4d00-949a-37317e40609c" />
---
BEFORE CHANGES:
<img width="1015" height="946" alt="Screenshot 2026-02-27 at 3 27 36 PM" src="https://github.com/user-attachments/assets/eb7a80ad-3274-487e-bd37-ae255f30b835" />
---

AFTER CHANGES:
<img width="1021" height="853" alt="Screenshot 2026-02-27 at 3 27 59 PM" src="https://github.com/user-attachments/assets/1cca1f33-3cf4-454e-b12e-39f23413100e" />
